### PR TITLE
Enable stand-alone usage of AVR STL port without Snowfox

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,47 @@ snowfox-avr-stl
 ### What?
 This repository contains the SGI STL library for usage with the Snowfox embedded framework without iostreams.
 
+### How-to-use without the Snowfox embedded framework?
+Create a file `src/new.cpp` with the following content and compile it with your application.
+```C++
+#include <new>
+
+void * operator new(size_t size)
+{
+  return malloc(size);
+}
+
+void * operator new(size_t size, void * ptr)
+{
+  (void)size;
+  return ptr;
+}
+
+void operator delete(void * ptr)
+{
+  if(ptr)
+  {
+    free(ptr);
+  }
+}
+
+void operator delete(void * ptr, size_t /* size */)
+{
+  return ::operator delete(ptr);
+}
+
+void * operator new[] (size_t size)
+{
+  return ::operator new(size);
+}
+
+void operator delete[] (void *ptr)
+{
+  return ::operator delete(ptr);
+}
+
+void operator delete[](void * ptr, size_t /* size */)
+{
+  return ::operator delete(ptr);
+}
+```

--- a/include/new
+++ b/include/new
@@ -1,6 +1,28 @@
 #ifndef SNOWFOX_AVR_STL_NEW_H_
 #define SNOWFOX_AVR_STL_NEW_H_
 
-#include <snowfox/cpu/avr/cxx.h>
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#ifdef MCU_ARCH_avr
+  #include <snowfox/cpu/avr/cxx.h>
+#else
+  #include <stdlib.h>
+#endif
+
+/**************************************************************************************
+ * FUNCTION DECLARATION
+ **************************************************************************************/
+
+#ifndef MCU_ARCH_avr
+void * operator new     (size_t   size);
+void * operator new     (size_t size, void * ptr);
+void   operator delete  (void   * ptr );
+void   operator delete  (void   * ptr, size_t size);
+void * operator new[]   (size_t   size);
+void   operator delete[](void   * ptr );
+void   operator delete[](void   * ptr, size_t size);
+#endif
 
 #endif /* SNOWFOX_AVR_STL_NEW_H_ */


### PR DESCRIPTION
In case the AVR STL library is compiled without the snowfox framework we need to provide the memory allocation operators by ourselves. The header file 'new' has been expanded to provide the necessary definitions and the README has been updated to tell the user how to use this library.

This fixes #1 .